### PR TITLE
rustfmt and llvm-tools are not preview anymore

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,10 +2,10 @@
 channel = "nightly-2023-02-01"
 components = [
     # https://github.com/rust-lang/rust/issues/72594#issuecomment-633779564
-    "llvm-tools-preview",
+    "llvm-tools",
     # For components/script_plugins, https://github.com/rust-lang/rust/pull/67469
     "rustc-dev",
     "rust-docs",
-    "rustfmt-preview",
+    "rustfmt",
 ]
 profile = "minimal"


### PR DESCRIPTION
As discussed in https://github.com/servo/servo/pull/30112#discussion_r1297331309


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [x] These changes do not require tests because they are no op

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
